### PR TITLE
Fix example script for new client versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ VENVDEPS=$(REQUIREMENTS setup.py)
 NPMDEPS=$(package-lock.json)
 
 $(VENV):
-	python -m venv .venv
-	$(VENV)/python -m pip install --upgrade pip
+	python3 -m venv .venv
+	$(VENV)/python3 -m pip install --upgrade pip
 
 $(VENV)/$(MARKER): $(VENVDEPS) | $(VENV)
 	$(VENV)/pip install $(foreach path,$(REQUIREMENTS),-r $(path))
@@ -27,7 +27,7 @@ clean:
 	rm -rf $$(cat .gitignore)
 
 test-android: install
-	$(NPM)/percy app:exec -- $(VENV)/python tests/android.py
+	$(NPM)/percy app:exec -- $(VENV)/python3 tests/android.py
 
 test-ios: install
-	$(NPM)/percy app:exec -- $(VENV)/python tests/ios.py
+	$(NPM)/percy app:exec -- $(VENV)/python3 tests/ios.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # example-percy-appium-python
 Example app used by the [Percy Python Appium tutorial](https://docs.percy.io/v2-app/docs/appium-for-python) demonstrating Percy's Python Appium integration.
 
+Note: This tutorial works with Appium-Python-Client >= 2.10.2 
+
 ## Python Appium Tutorial
 
 The tutorial assumes you're already familiar with Python and

--- a/tests/android.py
+++ b/tests/android.py
@@ -1,6 +1,7 @@
 import time
 from appium import webdriver
 from appium.webdriver.common.appiumby import AppiumBy
+from appium.options.android import UiAutomator2Options
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from percy import percy_screenshot
@@ -10,7 +11,8 @@ ACCESS_KEY = "App Automate Access key"
 
 
 def run_session(capability):
-    driver = webdriver.Remote('https://hub-cloud.browserstack.com/wd/hub', capability)
+    options = UiAutomator2Options().load_capabilities(capability)
+    driver = webdriver.Remote('https://hub-cloud.browserstack.com/wd/hub', options=options)
     percy_screenshot(driver, 'screenshot 1')
 
     search_element = WebDriverWait(driver, 30).until(

--- a/tests/ios.py
+++ b/tests/ios.py
@@ -2,6 +2,7 @@ import time
 
 from appium import webdriver
 from appium.webdriver.common.appiumby import AppiumBy
+from appium.options.ios import XCUITestOptions
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from percy import percy_screenshot
@@ -11,8 +12,8 @@ ACCESS_KEY = "App Automate Access key"
 
 
 def run_session(capability):
-    driver = webdriver.Remote("https://hub-cloud.browserstack.com/wd/hub",
-                              capability)
+    options = XCUITestOptions().load_capabilities(capability)
+    driver = webdriver.Remote("https://hub-cloud.browserstack.com/wd/hub", options=options)
     text_button = WebDriverWait(driver, 30).until(
         EC.element_to_be_clickable((AppiumBy.ACCESSIBILITY_ID, "Text Button"))
     )


### PR DESCRIPTION
- Capability is deprecated in newer Appium client versions (> 2.3) latest being 3.1.0, so updating to latest syntax.